### PR TITLE
Allow user to change password

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,5 +1,5 @@
 class AuthenticationController < ApplicationController
-  skip_before_action :authenticate_user
+  skip_before_action :authenticate_user, only: :create
 
   def create
     @user = User.find_by(username: params[:username])
@@ -16,5 +16,9 @@ class AuthenticationController < ApplicationController
   def destroy
     @current_user&.update(jti: nil)
     render json: { status: 200, message: 'Logged out' }
+  end
+
+  def show
+    render json: @current_user.attributes.except('password', 'password_digest'), status: 200
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,11 +15,16 @@ class UsersController < ApplicationController
   end
 
   def update
-    if current_user.update(user_params)
-      render json: current_user, status: 200
-    else
-      render json: { errors: current_user.errors.full_messages }, status: 400
+    if params[:password].present?
+      if current_user.update(user_update_params)
+        render json: current_user.attributes.except('password', 'password_digest'), status: 200
+      else
+        render json: { errors: current_user.errors.full_messages }, status: 400
+      end
+      return
     end
+
+    render json: { errors: 'Password can\'t be blank' }, status: 400
   end
 
   def destroy
@@ -30,6 +35,10 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name, :username, :email, :password)
+  end
+
+  def user_update_params
+    params.require(:user).permit(:password)
   end
 
   def current_user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,13 @@
 Rails.application.routes.draw do
   scope 'api' do
     scope 'v1' do
-      resources :users, only: %i[create update destroy show]
+      resources :users, only: %i[create destroy]
+      patch 'users', to: 'users#update'
       resources :rooms, only: %i[create destroy show index]
 
       post 'authentication', to: 'authentication#create'
       delete 'authentication', to: 'authentication#destroy'
+      get 'authentication', to: 'authentication#show'
     end
   end
 end


### PR DESCRIPTION
Hi team, in this PR I added extra functionality to the user controller and modified some endpoints:

- Allow changing the password to the `current_user`.
- Move show `current_user` from `get` '/api/v1/users/:id' to `get` '/api/v1/authentication'
- User URL id is not needed anymore to change the `current_user` password